### PR TITLE
[13] Remove unnecessary SBT trickery that breaks makeSite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,7 @@
 enablePlugins(TutPlugin, GhpagesPlugin)
 
 scalaVersion                  := "2.12.8"
-tutTargetDirectory            := siteDirectory.value
 includeFilter in makeSite     := "*.yml" | "*.md" | "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.eot" | "*.svg" | "*.ttf" | "*.woff" | "*.woff2" | "*.otf"
-makeSite                      := makeSite.dependsOn(tut).value
 git.remoteRepo                := "git@github.com:nrinaudo/scala-best-practices.git"
 ghpagesNoJekyll               := false
 


### PR DESCRIPTION
This was a leftover from when this site used PreprocessPlugin and
should have been removed already.

Fixes #13.