### PR TITLE
Add references to Scalafix/Scalafmt rules

### DIFF
--- a/src/main/mdoc/_adts/enumerations_as_adt.md
+++ b/src/main/mdoc/_adts/enumerations_as_adt.md
@@ -6,6 +6,10 @@ linters:
     rules:
       - name: Enumeration
         url:  http://www.wartremover.org/doc/warts.html#enumeration
+  - name: scalafix
+    rules:
+      - name: Disable.symbols = [ "scala.Enumeration" ]
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > When you need to implement an enumeration, use an [ADT], not [`Enumeration`].

--- a/src/main/mdoc/_adts/product_with_serializable.md
+++ b/src/main/mdoc/_adts/product_with_serializable.md
@@ -1,6 +1,11 @@
 ---
 title: Make ADTs subtypes of Product and Serializable
 layout: article
+linters:
+  - name: scalafix
+    rules:
+      - name: NoInfer.disabledTypes = [ "scala.Serializable", "scala.Product" ]
+        url: https://github.com/eed3si9n/scalafix-noinfer
 ---
 
 > When writing an [ADT], always have the root type extend [`Product`] and [`Serializable`].

--- a/src/main/mdoc/_binary_compat/explicit_type_annotations.md
+++ b/src/main/mdoc/_binary_compat/explicit_type_annotations.md
@@ -6,6 +6,10 @@ linters:
     rules:
       - name: PublicInference
         url:  http://www.wartremover.org/doc/warts.html#publicinference
+  - name: scalafix
+    rules:
+      - name: ExplicitResultTypes
+        url: https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html
 ---
 
 > Always add an explicit type to your public members, even when you're happy with what's being inferred.

--- a/src/main/mdoc/_oop/abstract_fields_as_defs.md
+++ b/src/main/mdoc/_oop/abstract_fields_as_defs.md
@@ -1,6 +1,11 @@
 ---
 title: Declare abstract fields as paren-less methods
 layout: article
+linters:
+  - name: scalafix
+    rules:
+      - name: DisableSyntax.noValInAbstract = true
+        url: https://scalacenter.github.io/scalafix/docs/rules/DisableSyntax.html
 ---
 
 > When declaring abstract fields in an abstract class or a trait, it's good practice to declare them as [paren-less] methods.

--- a/src/main/mdoc/_partial_functions/either_projection_get.md
+++ b/src/main/mdoc/_partial_functions/either_projection_get.md
@@ -9,6 +9,10 @@ linters:
   - name: scapegoat
     rules:
       - name: EitherGet
+  - name: scalafix
+    rules:
+      - name: Disable.symbols = [ "scala.util.Either.LeftProjection.get", "scala.util.Either.RightProjection.get" ]
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > When retrieving the content of an [`Either`], do not use [`get`] on one of its projections.

--- a/src/main/mdoc/_partial_functions/option_get.md
+++ b/src/main/mdoc/_partial_functions/option_get.md
@@ -9,6 +9,10 @@ linters:
   - name: scapegoat
     rules:
       - name: OptionGet
+  - name: scalafix
+    rules:
+      - name: Disable.symbols = [ "scala.Option.get", "scala.Some.get", "scala.None.get" ]
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > When retrieving the content of an [`Option`], do not use [`get`].

--- a/src/main/mdoc/_partial_functions/try_get.md
+++ b/src/main/mdoc/_partial_functions/try_get.md
@@ -9,6 +9,10 @@ linters:
   - name: scapegoat
     rules:
       - name: TryGet
+  - name: scalafix
+    rules:
+      - name: Disable.symbols = [ "scala.util.Try.get", "scala.util.Failure.get", "scala.util.Success.get" ]
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > When retrieving the content of a [`Try`], do not use [`get`].

--- a/src/main/mdoc/_referential_transparency/avoid_mutability.md
+++ b/src/main/mdoc/_referential_transparency/avoid_mutability.md
@@ -8,6 +8,10 @@ linters:
         url:  http://www.wartremover.org/doc/warts.html#var
       - name: MutableDataStructures
         url: http://www.wartremover.org/doc/warts.html#mutabledatastructures
+  - name: scalafix
+    rules:
+      - name: Disable.symbols = [ "scala.collection.mutable" ]
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > Mutability is almost always a bad idea and should be avoided.

--- a/src/main/mdoc/_referential_transparency/avoid_return.md
+++ b/src/main/mdoc/_referential_transparency/avoid_return.md
@@ -13,6 +13,10 @@ linters:
     rules:
       - name: ReturnChecker
         url:  http://www.scalastyle.org/rules-1.0.0.html#org_scalastyle_scalariform_ReturnChecker
+  - name: scalafix
+    rules:
+      - name: DisableSyntax.noReturns = true
+        url: https://scalacenter.github.io/scalafix/docs/rules/DisableSyntax.html
 ---
 
 > There's never a good reason to use the `return` keyword.

--- a/src/main/mdoc/_referential_transparency/avoid_throwing_exceptions.md
+++ b/src/main/mdoc/_referential_transparency/avoid_throwing_exceptions.md
@@ -6,6 +6,10 @@ linters:
     rules:
       - name: Throw
         url:  http://www.wartremover.org/doc/warts.html#throw
+  - name: scalafix
+    rules:
+      - name: DisableSyntax.noThrows = true
+        url: https://scalacenter.github.io/scalafix/docs/rules/DisableSyntax.html
 ---
 
 > Do not throw exceptions if you can possibly avoid it.

--- a/src/main/mdoc/_tricky_behaviours/final_case_classes.md
+++ b/src/main/mdoc/_tricky_behaviours/final_case_classes.md
@@ -9,6 +9,10 @@ linters:
   - name: scapegoat
     rules:
       - name: FinalModifierOnCaseClass
+  - name: scalafix
+    rules:
+      - name: MissingFinal.noLeakingCaseClass = true
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > When declaring a case class, make it [`final`].

--- a/src/main/mdoc/_tricky_behaviours/leaky_sealed_types.md
+++ b/src/main/mdoc/_tricky_behaviours/leaky_sealed_types.md
@@ -6,6 +6,10 @@ linters:
     rules:
       - name: LeakingSealed
         url:  http://www.wartremover.org/doc/warts.html#leakingsealed
+  - name: scalafix
+    rules:
+      - name: MissingFinal.noLeakingSealed = true
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > When writing a subtype for a [`sealed`] type, mark it as [`final`].

--- a/src/main/mdoc/_tricky_behaviours/string_concatenation.md
+++ b/src/main/mdoc/_tricky_behaviours/string_concatenation.md
@@ -6,6 +6,10 @@ linters:
     rules:
       - name: StringPlusAny
         url:  http://www.wartremover.org/doc/warts.html#stringplusany
+  - name: scalafix
+    rules:
+      - name: Disable.ifSynthetic = [ "scala.Predef.any2stringadd" ]
+        url: https://github.com/vovapolu/scaluzzi
 ---
 
 > When concatenating something to a [`String`], consider string interpolation rather than [`+`].

--- a/src/main/mdoc/_tricky_behaviours/type_implicits.md
+++ b/src/main/mdoc/_tricky_behaviours/type_implicits.md
@@ -6,6 +6,10 @@ linters:
     rules:
       - name: ExplicitImplicitTypes
         url:  http://www.wartremover.org/doc/warts.html#explicitimplicittypes
+  - name: scalafix
+    rules:
+      - name: ExplicitResultTypes.skipLocalImplicits = false
+        url: https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html
 ---
 
 > Always add an explicit type to your implicit values or methods, even when they're private

--- a/src/main/mdoc/_tricky_behaviours/unicode_operators.md
+++ b/src/main/mdoc/_tricky_behaviours/unicode_operators.md
@@ -6,6 +6,10 @@ linters:
     rules:
       - name: NonASCIICharacterChecker
         url:  http://www.scalastyle.org/rules-1.0.0.html#org_scalastyle_scalariform_NonASCIICharacterChecker
+  - name: scalafmt
+    rules:
+      - name: rewriteTokens
+        url:  https://scalameta.org/scalafmt/docs/configuration.html#rewritetokens
 ---
 
 > ASCII operators (such as `->`) should be preferred over their fancy unicode equivalents (such as `→`).

--- a/src/main/mdoc/_unsafe/avoid_null.md
+++ b/src/main/mdoc/_unsafe/avoid_null.md
@@ -14,6 +14,10 @@ linters:
     rules:
       - name: NullChecker
         url:  http://www.scalastyle.org/rules-1.0.0.html#org_scalastyle_scalariform_NullChecker
+  - name: scalafix
+    rules:
+      - name: DisableSyntax.noNulls = true
+        url: https://scalacenter.github.io/scalafix/docs/rules/DisableSyntax.html
 ---
 
 > Whenever `null` seems like a good idea, use [`Option`] instead.

--- a/src/site/_includes/linters.html
+++ b/src/site/_includes/linters.html
@@ -24,6 +24,12 @@
     {% when 'scalastyle' %}
     {% assign linter_name = 'Scalastyle' %}
     {% assign linter_url = 'http://www.scalastyle.org/' %}
+    {% when 'scalafix' %}
+    {% assign linter_name = 'Scalafix' %}
+    {% assign linter_url = 'https://scalacenter.github.io/scalafix/' %}
+    {% when 'scalafmt' %}
+    {% assign linter_name = 'Scalafmt' %}
+    {% assign linter_url = 'https://scalameta.org/scalafmt/' %}
     {% else %}
     {% assign linter_url = false %}
     {% endcase %}


### PR DESCRIPTION
Thanks for the website, I love it for the clear and concise explanations ❤️ 

I added references to Scalafix rules. They don't cover everything, but it's a start. Some of the rules are not part of the the core Scalafix, but that's the cool thing about it: it's easy to extend. I added links, so it should be fine at least as the initial reference.

The problem with these additions is that sometimes Scalafix rules are very generic (like `Disable.symbol`), so they need extra configuration. I'm not sure if the current layout accommodates these longer references well. For example:


<img width="757" alt="Screenshot 2020-05-25 at 23 00 15" src="https://user-images.githubusercontent.com/766656/82842897-9733c400-9edb-11ea-950f-32471135ffa3.png">

Maybe there could be 3 columns: linter, rule, configuration?
Let me know what you think 🙂 

Also, Scalafmt is not a linter, but it has syntactic rewrites, so I added it for the Unicode operators.